### PR TITLE
Changed class names to be italicized and therefore easier to read.

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -195,7 +195,8 @@
 
 .support {
   &.class {
-    color: @light-orange;
+    font-style: italic;
+    color: @purple;
   }
 
   &.function  {


### PR DESCRIPTION
Also made class names the, mostly unused, purple color to further make them distinct.

I've confirmed this change works for Ruby and Javascript.
