### PR TITLE
Fixed deprecation warnings caused by the latest Atom updates.

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -1,11 +1,7 @@
 @import "syntax-variables";
 
-.editor-colors {
-  background-color: @syntax-background-color;
-  color: @syntax-text-color;
-}
-
-.editor {
+atom-text-editor, // <- remove when Shadow DOM can't be disabled
+:host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -56,12 +52,12 @@
   }
 }
 
-.editor .search-results .marker .region {
+atom-text-editor .search-results .marker .region {
   background-color: transparent;
   border: 2px solid @syntax-result-marker-color;
 }
 
-.editor .search-results .marker.current-result .region {
+atom-text-editor .search-results .marker.current-result .region {
   border: 2px solid @syntax-result-marker-color-selected;
 }
 
@@ -307,6 +303,6 @@
   }
 }
 
-.editor.mini .scroll-view {
+atom-text-editor[mini] .scroll-view {
   padding-left: 1px;
 }


### PR DESCRIPTION
Line 3 can be removed in the future when Shadow DOM can’t be
disabled.
